### PR TITLE
manual boost install to deal with cpp11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,10 @@ addons:
     - ubuntu-toolchain-r-test
    packages:
     - libhdf5-serial-dev
-    - libboost-program-options-dev
     - libcairo2-dev
     - doxygen
     - doxygen-latex
     - graphviz
-    - libboost-system-dev
     - libgmp-dev
     - libgdcm2-dev 
     - libgraphicsmagick++1-dev
@@ -34,17 +32,33 @@ addons:
  
 
 before_install:
-  - if [ $CXX == "g++" ]; then CCOMPILER="gcc-4.8"; CXXCOMPILER="g++-4.8"; fi
+  - env
+  - export SRC_DIR="`pwd`"
+  - if [ $CXX == "g++" ]; then export CXX="g++-4.8"  CC="gcc-4.8" BOOST_TOOLSET=gcc CCOMPILER="gcc-4.8" CXXCOMPILER="g++-4.8"; fi
+  - if [ "$CXX" = "clang++" ]; then export BOOST_TOOLSET=clang; fi
+  # Manual boost install since linking fails with libboost-program-options1.46-dev and g++48
+  - export DOWNLOAD_ROOT="$HOME/download"; if [ ! -d "$DOWNLOAD_ROOT" ]; then mkdir -p "$DOWNLOAD_ROOT"; fi
+  - export BOOST_DOWNLOAD_URL="http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.bz2/download"
+  - export BOOST_ROOT="$TRAVIS_BUILD_DIR/../boost"
+  - export CMAKE_MODULE_PATH="$BOOST_ROOT"
+  - if [ ! -f "$DOWNLOAD_ROOT/boost.tar.bz2" ]; then wget --no-verbose --output-document="$DOWNLOAD_ROOT/boost.tar.bz2" "$BOOST_DOWNLOAD_URL"; fi
+  - if [ ! -d "$BOOST_ROOT" ]; then mkdir -p "$BOOST_ROOT" && tar jxf "$DOWNLOAD_ROOT/boost.tar.bz2" --strip-components=1 -C "$BOOST_ROOT"; fi
+  - if [ ! -f "$BOOST_ROOT/b2" ]; then cd "$BOOST_ROOT"; ./bootstrap.sh --with-toolset="$BOOST_TOOLSET" --with-libraries=program_options; fi
 
 
 before_script:
+  - ccache -V && ccache --show-stats && ccache --zero-stats
+  - 'echo "using gcc : : ccache $CXX : <cflags>-std=c11 <cxxflags>-std=c++11 ;" > ~/user-config.jam'
+  - 'echo "using clang : : ccache $CXX : <cflags>-std=c11 <cxxflags>-std=c++11 ;" >> ~/user-config.jam'
+  - cd "$BOOST_ROOT"; ./b2 toolset="$BOOST_TOOLSET" threading=multi --prefix="$BOOST_ROOT" -d0 install
+  - cd $SRC_DIR
   - git clone git://github.com/DGtal-team/DGtal.git
   - cd DGtal
-  - cmake . $DGTALTYPE  -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER
+  - cmake . $DGTALTYPE  -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER -DBOOST_ROOT=$BOOST_ROOT
   - make 
   - cd ..
 
 script: 
-   - cmake . -DCMAKE_BUILD_TYPE=Debug -DDGtal_DIR=$PWD/DGtal
+   - cmake . -DCMAKE_BUILD_TYPE=Debug -DDGtal_DIR=$PWD/DGtal -DCMAKE_CXX_COMPILER=$CXXCOMPILER -DCMAKE_C_COMPILER=$CCOMPILER -DBOOST_ROOT=$BOOST_ROOT
    - make
 


### PR DESCRIPTION
(same as DGtalTools)

Previously the DGtalTools-contrib compile was not using the cpp11 options, this PR fix it.
(For now it looks that we need to have a manual boost install in the new travis docker based arch (else we have a strange boost linking issue))