### PR TITLE
Fixing PointVector implicit conversions (in link with DGtal PR #1345)

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,10 @@
   - displayLineSegments: new option to display a second set of lines.
     (Bertrand Kerautret, 
     [#33](https://github.com/DGtal-team/DGtalTools-contrib/pull/43))
-
+- *global*
+  - Fix PointVector implicit conversion (in link to DGtal PR #1345)
+    (Bertrand Kerautret 
+    [#45](https://github.com/DGtal-team/DGtalTools/pull/45))
 
 # DGtalTools-contrib  0.9.4
 - *global*

--- a/geometry3d/basicEditMesh.cpp
+++ b/geometry3d/basicEditMesh.cpp
@@ -152,7 +152,7 @@ main(int argc,char **argv)
 
     if( vm.count("shrinkArea")){
       Z3i::Domain aDomain(ptLower, ptUpper);
-      TPoint ptCenter = (p0+p1+p2)/3.0;
+      Z3i::Point ptCenter( (p0+p1+p2)/3.0, functors::Round<>());
       if(aDomain.isInside(ptCenter)){
         for(unsigned int i =0; i<3; i++){
           TPoint &aVertex = theNewMesh.getVertex(aFace.at(i));


### PR DESCRIPTION
# PR Description

See PR [#1345](https://github.com/DGtal-team/DGtal/pull/1345)
done:
 - [x] `geometry3d/basicEditMesh.cpp`

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).