### PR TITLE
Fix color export in off2obj

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -10,6 +10,11 @@
   (Bertrand Kerautret [#48](https://github.com/DGtal-team/DGtalTools-contrib/pull/48))
 
 
+- *Geometry3d*
+  - fix off2obj: the colors of .off are now well exported in obj.
+   (Bertrand Kerautret [#49](https://github.com/DGtal-team/DGtalTools-contrib/pull/49))   
+
+
 # DGtalTools-contrib  1.0
 - *visualisation*
   - displayLineSegments: new option to display a second set of lines.

--- a/geometry3d/off2obj.cpp
+++ b/geometry3d/off2obj.cpp
@@ -127,7 +127,7 @@ int main( int argc, char** argv )
   std::string basename = outputFileName.substr(0, outputFileName.find_last_of("."));
   std::stringstream outname; outname << basename << ".obj"; 
   // read input mesh
-  DGtal::Mesh<DGtal::Z3i::RealPoint> aMesh;
+  DGtal::Mesh<DGtal::Z3i::RealPoint> aMesh(vm.count("colors"));
 
   MeshReader<DGtal::Z3i::RealPoint>::importOFFFile(inputFileName,
                                                    aMesh, vm.count("invertNormals"));


### PR DESCRIPTION
# PR Description

 fix off2obj: the colors of .off are now well exported in obj.

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
