### PR TITLE
Fix travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: cpp
 dist: xenial
-
-
+osx_image: xcode12.2
 
 compiler:
   - gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,7 @@
 PROJECT(DGtalTools-contrib)
 
 cmake_minimum_required (VERSION 3.1) 
+cmake_policy(SET CMP0057 NEW)
 
 SET(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
@@ -62,23 +63,6 @@ SET(VERSION ${DGtalToolsContrib_VERSION_MAJOR}.${DGtalToolsContrib_VERSION_MINOR
 
 
 
-
- # -----------------------------------------------------------------------------
- # Looking for boost
- # -----------------------------------------------------------------------------
-set(Boost_USE_STATIC_LIBS   ON)
-set(Boost_USE_MULTITHREADED ON)
-set(Boost_USE_STATIC_RUNTIME OFF)
-set(Boost_FOUND FALSE)
-FIND_PACKAGE(Boost 1.50.0 REQUIRED)
-if ( Boost_FOUND )
-  ADD_DEFINITIONS(${BOOST_DEFINITIONS} -DBOOST_ALL_NO_LIB)
-  # SYSTEM to avoid warnings from boost.
-  include_directories(SYSTEM ${Boost_INCLUDE_DIRS} )
-  SET(DGtalToolsContribLibDependencies ${DGtalToolsContribLibDependencies}
-     ${Boost_LIBRAIRIES})
-   SET(DGtalLibInc ${Boost_INCLUDE_DIRS})  
-endif( Boost_FOUND )
 
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 # DGtalTools-contrib  1.2
 
 - *global*
-  - Travis: Fix old default osx_image with xcode12.2 and remove non used boost
+  - Fix Appveyor and Travis  wioth old default osx_image with xcode12.2 and remove non used boost
     cmake references. (Bertrand Kerautret [#53](https://github.com/DGtal-team/DGtalTools/pull/53)) 
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,13 @@
+
+# DGtalTools-contrib  1.2
+
+- *global*
+  - Travis: Fix old default osx_image with xcode12.2 and remove non used boost
+    cmake references. (Bertrand Kerautret [#53](https://github.com/DGtal-team/DGtalTools/pull/53)) 
+
+
+
+
 # DGtalTools-contrib  1.1
 
 - *global*

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.9beta.{build}
+version: 1.0.{build}
 
 environment:
   BOOST_ROOT: "C:\\Libraries\\boost_1_63_0"
@@ -69,7 +69,7 @@ before_build:
   - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG% -DWITH_QGLVIEWER:BOOL=ON -DWITH_QT5:BOOL=ON -DQGLVIEWER_INCLUDE_DIR=C:\projects\libqglviewer -DQGLVIEWER_LIBRARIES=C:\projects\libqglviewer\QGLViewer\QGLViewer2.lib -DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=FALSE  -DZLIB_LIBRARY=c:/zlib-install/lib/zlibd.lib -DZLIB_INCLUDE_DIR=c:/zlib-install/include/  -DBOOST_ROOT=%BOOST_ROOT% .
   - msbuild /m /p:Configuration=%CONFIG% /p:Platform=%B_NAME% DGtal.sln 
   - cd %APPVEYOR_BUILD_FOLDER%
-  - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG%   -DBOOST_ROOT=%BOOST_ROOT%   -DBOOST_LIBRARYDIR="%BOOST_LIBRARYDIR%" -DDGtal_DIR=C:\projects\dgtal .
+  - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG%   -DDGtal_DIR=C:\projects\dgtal .
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -69,7 +69,7 @@ before_build:
   - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG% -DWITH_QGLVIEWER:BOOL=ON -DWITH_QT5:BOOL=ON -DQGLVIEWER_INCLUDE_DIR=C:\projects\libqglviewer -DQGLVIEWER_LIBRARIES=C:\projects\libqglviewer\QGLViewer\QGLViewer2.lib -DBUILD_TESTING:BOOL=OFF -DBUILD_EXAMPLES:BOOL=OFF -DBUILD_SHARED_LIBS:BOOL=FALSE  -DZLIB_LIBRARY=c:/zlib-install/lib/zlibd.lib -DZLIB_INCLUDE_DIR=c:/zlib-install/include/  -DBOOST_ROOT=%BOOST_ROOT% .
   - msbuild /m /p:Configuration=%CONFIG% /p:Platform=%B_NAME% DGtal.sln 
   - cd %APPVEYOR_BUILD_FOLDER%
-  - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG%   -DDGtal_DIR=C:\projects\dgtal .
+  - cmake -Wno-dev -G"%VS_GEN%" -DCMAKE_BUILD_TYPE=%CONFIG% -DCMAKE_INSTALL_PREFIX:PATH=c:\zlib-install C:\zlib\zlib-1.2.9  -DDGtal_DIR=C:\projects\dgtal .
 
 
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   - VS_GEN: Visual Studio 14 2015
     CONFIG: RelWithDebInfo
     B_NAME: Win32
-    BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_59_0\\lib32-msvc-14.0"
+    BOOST_LIBRARYDIR: "C:\\Libraries\\boost_1_63_0\\lib32-msvc-14.0"    
     CONFIGQGL: Release
     QTDIR: "C:\\Qt\\5.6.3\\msvc2015"
 #  - VS_GEN: Visual Studio 14 2015 Win64


### PR DESCRIPTION
# PR Description

Travis: Fix old default osx_image with xcode12.2 and remove non used boost
    cmake references.

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
