### PR TITLE
bug fixed in visualisation/displayLineSegments.cpp

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,8 @@
 # DGtalTools-contrib  1.3 (beta)
 
-
+*visualisation*
+ - displayLineSegments: fix variable name and remove unused variables.
+   (Phuc Ngo  [#59](https://github.com/DGtal-team/DGtalTools-contrib/pull/59))
 
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # DGtalTools-contrib  1.3 (beta)
 
-*visualisation*
+- *visualisation*
  - displayLineSegments: fix variable name and remove unused variables.
    (Phuc Ngo  [#59](https://github.com/DGtal-team/DGtalTools-contrib/pull/59))
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,7 +1,7 @@
 # DGtalTools-contrib  1.3 (beta)
 
 - *visualisation*
- - displayLineSegments: fix variable name and remove unused variables.
+  - displayLineSegments: fix variable name and remove unused variables.
    (Phuc Ngo  [#59](https://github.com/DGtal-team/DGtalTools-contrib/pull/59))
 
 

--- a/visualisation/displayLineSegments.cpp
+++ b/visualisation/displayLineSegments.cpp
@@ -208,6 +208,7 @@ int main( int argc, char** argv )
   std::string inputSec;
   std::string output;
   std::string outputPDF;
+  std::string outputPNG;
   std::string outputEPS;
   std::string outputSVG;
   std::string backgroundImage;
@@ -324,15 +325,15 @@ int main( int argc, char** argv )
     else
       if (extension=="eps")
       {
-        aBoard.saveCairo(outputFileName.c_str(),Board2D::CairoEPS );
+        aBoard.saveCairo(output.c_str(),Board2D::CairoEPS );
       }
       else if (extension=="pdf")
       {
-        aBoard.saveCairo(outputFileName.c_str(),Board2D::CairoPDF );
+        aBoard.saveCairo(output.c_str(),Board2D::CairoPDF );
       }
       else if (extension=="png")
       {
-        aBoard.saveCairo(outputFileName.c_str(),Board2D::CairoPNG );
+        aBoard.saveCairo(output.c_str(),Board2D::CairoPNG );
       }
 #endif
       else if(extension=="eps")

--- a/visualisation/displayLineSegments.cpp
+++ b/visualisation/displayLineSegments.cpp
@@ -207,7 +207,6 @@ int main( int argc, char** argv )
   std::string inputFileName;
   std::string inputSec;
   std::string output;
-  std::string outputPDF;
   std::string outputPNG;
   std::string outputEPS;
   std::string outputSVG;
@@ -261,7 +260,6 @@ int main( int argc, char** argv )
 
 
 #ifdef WITH_CAIRO
-  app.add_option("--outputPDF", outputPDF, "outputPDF <filename> specify pdf format.");
   app.add_option("--outputPNG", outputPNG, "outputPNG <filename> specify pdf format.");
 #endif
 

--- a/visualisation/displayLineSegments.cpp
+++ b/visualisation/displayLineSegments.cpp
@@ -207,9 +207,6 @@ int main( int argc, char** argv )
   std::string inputFileName;
   std::string inputSec;
   std::string output;
-  std::string outputPNG;
-  std::string outputEPS;
-  std::string outputSVG;
   std::string backgroundImage;
   std::string outputStreamEPS;
   std::string outputStreamFIG;
@@ -257,11 +254,6 @@ int main( int argc, char** argv )
   app.add_flag("--outputStreamSVG", outputStreamSVG, "specify svg for output stream format.");
   app.add_flag("--outputStreamFIG", outputStreamFIG, "specify fig for output stream format.");
   app.add_flag("--invertYaxis", invertYaxis, "invertYaxis invert the Y axis for display contours (used only with --SDP)");
-
-
-#ifdef WITH_CAIRO
-  app.add_option("--outputPNG", outputPNG, "outputPNG <filename> specify pdf format.");
-#endif
 
   app.add_option("--backgroundImage", backgroundImage, "backgroundImage <filename> : display image as background");
   app.add_option("--alphaBG", alpha, "alphaBG <value> 0-1.0 to display the background image in transparency (default 1.0), (transparency works only if cairo is available)");


### PR DESCRIPTION
*Thanks a lot for contributing to DGtalTools-contrib, before submitting your PR, please fill up the description and make sure that all checkboxes are checked.*

# PR Description

Bugs of filenames no declared / wrong in the file *visualisation/displayLineSegments.cpp*

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
