### PR TITLE
new tool obj2off

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,16 @@
 
 - Continuous integration does not use Travis anymore but Github Actions.
   (Bertrand Kerautret [#58](https://github.com/DGtal-team/DGtalTools-contrib/pull/58))
+
 - *visualisation*
   - displayLineSegments: fix variable name and remove unused variables.
    (Phuc Ngo  [#59](https://github.com/DGtal-team/DGtalTools-contrib/pull/59))
+
+
+- *geometry3d*
+  - obj2off: converts a .obj mesh into the .off format.
+    (Bertrand Kerautret [#61](https://github.com/DGtal-team/DGtalTools-contrib/pull/61))
+    
 
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,7 +9,7 @@
 
 
 - *geometry3d*
-  - obj2off: converts a .obj mesh into the .off format.
+  - obj2off: converts an obj mesh to the .off format.
     (Bertrand Kerautret [#61](https://github.com/DGtal-team/DGtalTools-contrib/pull/61))
     
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ As the previous section but in 3d, it contains actually these tools:
    - volLocalMax: extract the local maximas of a vol image within a spherical kernel.
    - xyzScale: a basic tool to adjust the scale of an xyz file.
    - off2obj: tool to convert a mesh represented in off format into obj format.
+   - obj2off: tool to convert a .obj mesh into the .off format.
    - off2sdp: converts a mesh into a set of points (.sdp).
    
 | ![](https://cloud.githubusercontent.com/assets/772865/12481207/d20d246c-c047-11e5-8986-ae17a582c977.png)  |

--- a/geometry3d/CMakeLists.txt
+++ b/geometry3d/CMakeLists.txt
@@ -5,6 +5,7 @@ SET(DGTAL_TOOLS_DEVEL_SRC
     basicMorphoFilter
     xyzScale
     off2obj
+    obj2off
     off2sdp
 )
 

--- a/geometry3d/obj2off.cpp
+++ b/geometry3d/obj2off.cpp
@@ -1,0 +1,112 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file obj2off.cpp
+ * @ingroup geometry3d
+ * @author Bertrand Kerautret (\c kerautre@loria.fr )
+ * LORIA (CNRS, UMR 7503), University of Lorraine, France
+ *
+ * @date 2017/04/04
+ *
+ * Source file of the tool obj2off
+ *
+ * This file is part of the DGtal library/DGtalTools-contrib Project.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include <iostream>
+#include <fstream>
+
+#include "DGtal/base/Common.h"
+#include "DGtal/io/readers/MeshReader.h"
+#include "DGtal/io/writers/MeshWriter.h"
+#include "DGtal/helpers/StdDefs.h"
+
+#include "CLI11.hpp"
+
+
+///////////////////////////////////////////////////////////////////////////////
+using namespace std;
+using namespace DGtal;
+///////////////////////////////////////////////////////////////////////////////
+
+
+/**
+ @page obj2off obj2off
+ 
+ @brief   Converts a .obj mesh into the .off format.
+
+ @code
+ Typical use example:
+     obj2off -i file.obj -o file.off
+
+ Usage: ./geometry3d/obj2off [OPTIONS] 1 [2]
+
+ Positionals:
+   1 TEXT:FILE REQUIRED                  an input mesh file in .obj format.
+   2 TEXT                                an output file
+
+ Options:
+   -h,--help                             Print this help message and exit
+   -i,--input TEXT:FILE REQUIRED         an input mesh file in .obj format.
+   -o,--output TEXT                      an output file
+
+ 
+ @endcode
+
+ @b Example: 
+
+ @code
+ obj2off $DGtal/examples/samples/spot.obj converted.off
+ @endcode
+
+ @see
+ @ref obj2off.cpp
+
+ */
+
+
+int main( int argc, char** argv )
+{
+  
+  // parse command line using CLI ----------------------------------------------
+  CLI::App app;
+  std::string inputFileName;
+  std::string outputFileName {"result.off"};
+  
+  app.description("Converts a .obj mesh into the .off format.\n"
+                  "Typical use example:\n \t obj2off -i file.obj -o file.off \n");
+  app.add_option("-i,--input,1", inputFileName, "an input mesh file in .obj format." )
+  ->required()
+  ->check(CLI::ExistingFile);
+  app.add_option("--output,-o,2", outputFileName, "an output file ");
+
+ 
+  app.get_formatter()->column_width(40);
+  CLI11_PARSE(app, argc, argv);
+  // END parse command line using CLI ----------------------------------------------
+
+  // read input mesh
+  DGtal::Mesh<DGtal::Z3i::RealPoint> aMesh(true);
+
+  MeshReader<DGtal::Z3i::RealPoint>::importOBJFile(inputFileName, aMesh );
+  ofstream fout;
+  fout.open(outputFileName);
+  MeshWriter<DGtal::Z3i::RealPoint>::export2OFF(fout, aMesh);
+  return 0;
+}
+


### PR DESCRIPTION
# PR Description

New tool to convert a .obj mesh into the .off format.


# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
