### PR TITLE
fix autoEdge option

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,7 +2,7 @@
 
 
 - Fix autoEdge option of GraphViewer  (inverted interpretation from CLI transform)
-  (Bertrand Kerautret [#64](https://github.com/DGtal-team/DGtalTools-contrib/pull/64))
+  (Bertrand Kerautret with Craig Hiernard [#64](https://github.com/DGtal-team/DGtalTools-contrib/pull/64))
 
 - Continuous integration does not use Travis anymore but Github Actions.
   (Bertrand Kerautret [#58](https://github.com/DGtal-team/DGtalTools-contrib/pull/58))

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,9 @@
 # DGtalTools-contrib  1.3 (beta)
 
+
+- Fix autoEdge option of GraphViewer  (inverted interpretation from CLI transform)
+  (Bertrand Kerautret [#64](https://github.com/DGtal-team/DGtalTools-contrib/pull/64))
+
 - Continuous integration does not use Travis anymore but Github Actions.
   (Bertrand Kerautret [#58](https://github.com/DGtal-team/DGtalTools-contrib/pull/58))
 

--- a/visualisation/graphViewer.cpp
+++ b/visualisation/graphViewer.cpp
@@ -93,6 +93,7 @@ int main( int argc, char** argv )
   std::string nameFileEdge;
   double r {1.0};
   bool useRadiiFile {false};
+  bool autoEdgeOpt {false};
   std::vector<unsigned int> vectColMesh;
   std::vector<unsigned int> vectColVertex;
   std::vector<unsigned int> vectColEdge;
@@ -102,7 +103,7 @@ int main( int argc, char** argv )
 
   app.add_option("--inputVertex,-v", nameFileVertex, "input file containing the vertex list.")->required()->check(CLI::ExistingFile);
   app.add_option("--inputEdge,-e", nameFileEdge, "input file containing the edge list.")->required()->check(CLI::ExistingFile);
-  auto autoEdgeOpt = app.add_flag("--autoEdge,-a", "generate edge list from vertex order.");
+  app.add_flag("--autoEdge,-a", autoEdgeOpt, "generate edge list from vertex order.");
   auto inputRadiiOpt = app.add_option("--inputRadii,-r", nameFileRadii, "input file containing the radius for each vertex.");
   app.add_option("--ballRadius,-b", r, "radius of vertex balls.", true);
   auto addMeshOpt = app.add_option("--addMesh,-m", meshName, "add mesh in the display.");
@@ -132,7 +133,7 @@ int main( int argc, char** argv )
   // Structures to store vertex and edges read in input files
   std::vector<Z3i::RealPoint> vectVertex = PointListReader<Z3i::RealPoint>::getPointsFromFile(nameFileVertex);
   std::vector<Z2i::Point> vectEdges;
-  if(autoEdgeOpt->count()>0)
+  if(!autoEdgeOpt)
   {
     vectEdges =  PointListReader<Z2i::Point>::getPointsFromFile(nameFileEdge);
   }


### PR DESCRIPTION
# PR Description
Fix autoEdge option of GraphViewer  (inverted interpretation from CLI transform), the option was inverted and could produce bad edge display (Thanks @CHiernard).

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Github Actions & appveyor).
