### PR TITLE
Basic edit mesh add

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,7 +5,10 @@
    (Bertrand Kerautret [#71](https://github.com/DGtal-team/DGtalTools-contrib/pull/71))
   - basicEditMesh: improvement of mesh read using generic reader/writer. 
     (Bertrand Kerautret [#72](https://github.com/DGtal-team/DGtalTools-contrib/pull/72))
- 
+  - meshBasicEdit: new name of basicEditMesh and addition of a new
+    option to rescale a shape according to its bounding box and a new size.
+    (Bertrand Kerautret [#73](https://github.com/DGtal-team/DGtalTools-contrib/pull/73))
+
 # DGtalTools-contrib  1.3 
 
 - *global*

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Geometry3d
 
 As the previous section but in 3d, it contains actually these tools:
 
-   - basicEditMesh: to apply basic mesh edition (scale change, mesh face contraction, face filtering).
+   - meshBasicEdit: to apply basic mesh edition (scale change, mesh face contraction, face filtering).
    - basicMorphoFilter: apply basic morpho filter from a ball structural element.
    - computeMeshDistances: computes for each face of a mesh A the minimal distance to another mesh B.
    - meshAxisCutter: cuts the input mesh according one axis into sereral separate meshes.

--- a/geometry3d/CMakeLists.txt
+++ b/geometry3d/CMakeLists.txt
@@ -1,5 +1,5 @@
 SET(DGTAL_TOOLS_DEVEL_SRC
-    basicEditMesh
+    meshBasicEdit
     computeMeshDistances
     volLocalMax
     basicMorphoFilter

--- a/geometry3d/basicEditMesh.cpp
+++ b/geometry3d/basicEditMesh.cpp
@@ -216,8 +216,8 @@ main(int argc,char **argv)
  
         }
     }
-  trace.info()<< "nbFaces init: " << theNewMesh.nbFaces() << std::endl;
-  trace.info()<< "New nbFaces: " << theMesh.nbFaces() << std::endl;  
+  trace.info()<< "nbFaces init: " << theMesh.nbFaces() << std::endl;
+  trace.info()<< "New nbFaces: " << theNewMesh.nbFaces() << std::endl;
   theNewMesh >> outputMeshName; 
   
   

--- a/geometry3d/basicEditMesh.cpp
+++ b/geometry3d/basicEditMesh.cpp
@@ -75,7 +75,8 @@ main(int argc,char **argv)
   double scale;
   double percentFirst;
   double percent;
-  
+  unsigned int rescaleToCube {0};
+    
   app.description("Apply basic mesh edition (scale change, mesh face contraction, face filtering).\n"
                   "Example: ./geometry3d/basicEditMesh ${DGtal}/examples/samples/tref.off --filterVisiblePart 0.3 resultFiltered.off");
 
@@ -94,7 +95,7 @@ main(int argc,char **argv)
   app.add_option("--ny,-y", ny, "arg = define the ny of the direction of filtering, see --filterVisiblePart.", true);
   app.add_option("--nz,-z", nz, "arg = define the nz of the direction of filtering, see --filterVisiblePart.", true);
   auto scaleOpt = app.add_option("--scale",scale, "change the scale factor" );
-  
+  app.add_option("--rescaleToCube", rescaleToCube, "change the scale factor of the input mesh such that its bounding box size corresponds to the size of a cube given as argument.", false);
   auto filterFF = app.add_option("--filterFirstFaces",percentFirst,"arg= X : filters the X% of the first faces of the input mesh.");
   auto filterNBF = app.add_option("--filterNbFaces",percent,  "arg = X % limits the number of face by keeping only X percent of faces." );
   
@@ -142,9 +143,15 @@ main(int argc,char **argv)
     moduloLimitFace = (int)(100.0/percent);
   } 
   
-
   DGtal::Mesh<Z3i::RealPoint> theMesh(true);
   theMesh << inputMeshName;
+  if (rescaleToCube != 0)
+  {
+      auto bb = theMesh.getBoundingBox();
+      auto s = bb.second-bb.first;
+      auto maxSize = *s.maxElement();
+      scale = rescaleToCube/maxSize;
+  }
 
   DGtal::Mesh<Z3i::RealPoint> theNewMesh(true);
 
@@ -208,7 +215,7 @@ main(int argc,char **argv)
     
   }  
 
-  if( scaleOpt->count()>0 )
+  if( scaleOpt->count()>0 || theMesh.nbFaces() != 0)
     {
       for(unsigned int i =0; i<theNewMesh.nbVertex(); i++)
         {

--- a/geometry3d/meshBasicEdit.cpp
+++ b/geometry3d/meshBasicEdit.cpp
@@ -155,7 +155,7 @@ main(int argc,char **argv)
       auto s = bb.second-bb.first;
       auto maxSize = *s.maxElement();
       if (rescaleInterToCube.size() == 0 || (maxSize > rescaleInterToCube[1] || maxSize < rescaleInterToCube[0])) {
-          scale = rescaleToCube/maxSize;
+          scale = rescaleToCube/(double)maxSize;
       }
   }
 

--- a/geometry3d/meshBasicEdit.cpp
+++ b/geometry3d/meshBasicEdit.cpp
@@ -75,8 +75,9 @@ main(int argc,char **argv)
   double scale;
   double percentFirst;
   double percent;
-  unsigned int rescaleToCube {0};
-    
+  unsigned int rescaleToCube {100};
+  std::vector<unsigned int> rescaleInterToCube;
+
   app.description("Apply basic mesh edition (scale change, mesh face contraction, face filtering).\n"
                   "Example: ./geometry3d/meshBasicEdit.cpp ${DGtal}/examples/samples/tref.off --filterVisiblePart 0.3 resultFiltered.off");
 
@@ -95,7 +96,10 @@ main(int argc,char **argv)
   app.add_option("--ny,-y", ny, "arg = define the ny of the direction of filtering, see --filterVisiblePart.", true);
   app.add_option("--nz,-z", nz, "arg = define the nz of the direction of filtering, see --filterVisiblePart.", true);
   auto scaleOpt = app.add_option("--scale",scale, "change the scale factor" );
-  app.add_option("--rescaleToCube", rescaleToCube, "change the scale factor of the input mesh such that its bounding box size corresponds to the size of a cube given as argument.", false);
+  auto rescaleToCubeOpt = app.add_option("--rescaleToCube", rescaleToCube, "change the scale factor of the input mesh such that its bounding box size corresponds to the size of a cube given as argument.", true);
+  app.add_option("--rescaleInterToCube", rescaleInterToCube, "same than rescaleToCube but only if the bounding box max size is outside the interval given as parameters.", false)
+    ->expected(2);
+
   auto filterFF = app.add_option("--filterFirstFaces",percentFirst,"arg= X : filters the X% of the first faces of the input mesh.");
   auto filterNBF = app.add_option("--filterNbFaces",percent,  "arg = X % limits the number of face by keeping only X percent of faces." );
   
@@ -145,12 +149,14 @@ main(int argc,char **argv)
   
   DGtal::Mesh<Z3i::RealPoint> theMesh(true);
   theMesh << inputMeshName;
-  if (rescaleToCube != 0)
+  if (rescaleToCubeOpt->count() >0  || rescaleInterToCube.size() != 0 )
   {
       auto bb = theMesh.getBoundingBox();
       auto s = bb.second-bb.first;
       auto maxSize = *s.maxElement();
-      scale = rescaleToCube/maxSize;
+      if (rescaleInterToCube.size() == 0 || (maxSize > rescaleInterToCube[1] || maxSize < rescaleInterToCube[0])) {
+          scale = rescaleToCube/maxSize;
+      }
   }
 
   DGtal::Mesh<Z3i::RealPoint> theNewMesh(true);

--- a/geometry3d/meshBasicEdit.cpp
+++ b/geometry3d/meshBasicEdit.cpp
@@ -65,7 +65,7 @@ main(int argc,char **argv)
   // parse command line using CLI ----------------------------------------------
   CLI::App app;
   std::string inputMeshName;
-  std::string outputMeshName;
+  std::string outputMeshName{"result.obj"};
   std::vector<double> vectDistAndBBox;
   std::vector<double> paramBallArea;
   double theMaxAngle;
@@ -84,7 +84,7 @@ main(int argc,char **argv)
       ->required()
       ->check(CLI::ExistingFile);
   
-  app.add_option("-o,—-output,2",outputMeshName,"arg = file.off : export the resulting mesh associated to the fiber extraction.");
+  app.add_option("-o,--output,2",outputMeshName,"arg = file.off : export the resulting mesh associated to the fiber extraction.");
   app.add_option("--shrinkArea,-s",vectDistAndBBox,"arg = <dist> <bounding box> apply a mesh shrinking on the defined area.")
   ->expected(7);
   app.add_option("--shrinkBallArea,-b", paramBallArea,  "arg = <dist> <x> <y> <z> <radius> apply a mesh shrinking on the  area defined by a ball centered at x y z.")

--- a/geometry3d/meshBasicEdit.cpp
+++ b/geometry3d/meshBasicEdit.cpp
@@ -15,11 +15,11 @@ using namespace DGtal;
 
 
 /**
- @page basicEditMesh basicEditMesh
+ @page basicEditMesh meshBasicEdit.cpp
  
  @brief  Apply the Rosin Threshold algorithm.
 
- @b Usage:   basicEditMesh [input]
+ @b Usage:   meshBasicEdit.cpp [input]
 
  @b Allowed @b options @b are :
  
@@ -48,12 +48,12 @@ using namespace DGtal;
  @b Example:
 
  @code
-   basicEditMesh ${DGtal}/examples/samples/tref.off --filterVisiblePart 0.3 toto.offbasicEditMesh -i
+   meshBasicEdit.cpp ${DGtal}/examples/samples/tref.off --filterVisiblePart 0.3 toto.offmeshBasicEdit.cpp -i
  @endcode
 
 
  @see
- @ref basicEditMesh.cpp
+ @ref meshBasicEdit.cpp.cpp
 
  */
 int
@@ -63,9 +63,9 @@ main(int argc,char **argv)
   typedef typename Z3i::RealPoint TPoint;
 
   // parse command line using CLI ----------------------------------------------
-     CLI::App app;
-     std::string inputMeshName;
-     std::string outputMeshName;
+  CLI::App app;
+  std::string inputMeshName;
+  std::string outputMeshName;
   std::vector<double> vectDistAndBBox;
   std::vector<double> paramBallArea;
   double theMaxAngle;
@@ -78,13 +78,13 @@ main(int argc,char **argv)
   unsigned int rescaleToCube {0};
     
   app.description("Apply basic mesh edition (scale change, mesh face contraction, face filtering).\n"
-                  "Example: ./geometry3d/basicEditMesh ${DGtal}/examples/samples/tref.off --filterVisiblePart 0.3 resultFiltered.off");
+                  "Example: ./geometry3d/meshBasicEdit.cpp ${DGtal}/examples/samples/tref.off --filterVisiblePart 0.3 resultFiltered.off");
 
   app.add_option("-i,--input,1", inputMeshName, "input file name of mesh vertex given as OFF format." )
       ->required()
       ->check(CLI::ExistingFile);
   
-  app.add_option("—-output,-o",outputMeshName,"arg = file.off : export the resulting mesh associated to the fiber extraction." );
+  app.add_option("-o,—-output,2",outputMeshName,"arg = file.off : export the resulting mesh associated to the fiber extraction.");
   app.add_option("--shrinkArea,-s",vectDistAndBBox,"arg = <dist> <bounding box> apply a mesh shrinking on the defined area.")
   ->expected(7);
   app.add_option("--shrinkBallArea,-b", paramBallArea,  "arg = <dist> <x> <y> <z> <radius> apply a mesh shrinking on the  area defined by a ball centered at x y z.")


### PR DESCRIPTION
# PR Description

new name of basicEditMesh and addition of a new option to rescale a shape according to its bounding box and a new size.

# Checklist

- [x] Doxygen documentation of the code completed (classes, methods, types, members...)
- [x] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [x] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [x] Update the readme with potentially a screenshot of the tools if it applies. 
- [x] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [x] All continuous integration tests pass (Github Actions & appveyor).
