### PR TITLE
Remove preprocessor fix stbImage MSVC link error

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,11 @@
 # DGtalTools-contrib  1.4 (beta)
+- *build*
+  - Remove STBimage preprocessor instruction used to fix MVSC that is 
+    no more usefull since DGtal PR [175](https://github.com/DGtal-team/DGtal/pull/1715) 
+    (Bertrand Kerautret [#79](https://github.com/DGtal-team/DGtalTools-contrib/pull/79))
+
+
+
 - *global*
   - Continuous integration on windows does not use Appveyopr anymore but Github Actions.
    (Bertrand Kerautret [#77](https://github.com/DGtal-team/DGtalTools-contrib/pull/77))

--- a/visualisation/polyMeshEdit.cpp
+++ b/visualisation/polyMeshEdit.cpp
@@ -28,7 +28,7 @@
  */
 
 ///////////////////////////////////////////////////////////////////////////////
-#define NO_ADD_STBIMAGE_IMPLEMENT //To avoid duplicated linking errors (like LNK2005 in MSVC)
+
 #include <iostream>
 #include <DGtal/base/Common.h>
 #include <DGtal/helpers/StdDefs.h>


### PR DESCRIPTION
# PR Description

 Remove STBimage preprocessor instruction used to fix MVSC that is no more usefull since DGtal PR [175](https://github.com/DGtal-team/DGtal/pull/1715) 

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
