### PR TITLE
fix windows CI build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ env:
   CONFIG_GLOBAL: 
   CONFIG_LINUX:  -DWITH_MAGICK=true -DWITH_GMP=true -DWITH_FFTW3=true -DWARNING_AS_ERROR=ON -DWITH_HDF5=true -DWITH_QGLVIEWER=true -DWITH_CAIRO=true  -DWITH_EIGEN=true -DDGTAL_ENABLE_FLOATING_POINT_EXCEPTIONS=true
   CONFIG_MAC:    -DWITH_EIGEN=true -DWITH_GMP=tue
-  CONFIG_WINDOWS: -DWITH_OPENMP=true -DENABLE_CONAN=true 
+  CONFIG_WINDOWS: -DWITH_OPENMP=true
 
 jobs:
   build:
@@ -44,12 +44,14 @@ jobs:
 
      - name: Create conan default profile
        if: matrix.os == 'windows-latest'
-       run: conan profile detect --force
-
+       run: |
+          conan profile detect --force
+  
+          
      - uses: actions/cache@v4
        if: matrix.os == 'windows-latest'
        with:
-         path: ~/.conan
+         path: ~/.conan2
          key: ${{ runner.os }}-conan2-Release
 
 
@@ -88,13 +90,13 @@ jobs:
        shell: bash
        working-directory: ${{runner.workspace}}/build
        run: |
-           conan install $GITHUB_WORKSPACE --build=missing
            git clone --depth 1 https://github.com/DGtal-team/DGtal.git
            cd DGtal
+           conan install . --build=missing
            mkdir buildDGtal
            cd buildDGtal
-           echo  cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"  -DBUILD_EXAMPLES=false -DBUILD_TESTING=false 
-           cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" -DBUILD_EXAMPLES=false -DBUILD_TESTING=false  
+           echo  cmake .. -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"  -DBUILD_EXAMPLES=false -DBUILD_TESTING=false 
+           cmake .. -DCMAKE_POLICY_DEFAULT_CMP0091=NEW -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" -DBUILD_EXAMPLES=false -DBUILD_TESTING=false  
            cmake --build . --config Release --parallel 3
 
      - name: Configure CMake (linux)
@@ -114,7 +116,7 @@ jobs:
        working-directory: "${{runner.workspace}}/build"
        run: |
            conan install $GITHUB_WORKSPACE --build=missing
-           cmake $GITHUB_WORKSPACE -DCMAKE_MODULE_PATH="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal" -DDGtal_DIR="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal"  -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DDGTAL_RANDOMIZED_TESTING_WHITELIST="${{ steps.whitelist.outputs.WHITELIST }}"
+           cmake $GITHUB_WORKSPACE -DCMAKE_POLICY_DEFAULT_CMP0091=NEW  -DCMAKE_MODULE_PATH="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal" -DDGtal_DIR="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal"  -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DDGTAL_RANDOMIZED_TESTING_WHITELIST="${{ steps.whitelist.outputs.WHITELIST }}"
 
      - name: Build
        working-directory: ${{runner.workspace}}/build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,17 +40,17 @@ jobs:
        id: conan
        uses: turtlebrowser/get-conan@main
        with:
-         version: 1.57.0
+         version: 2.4.0
 
      - name: Create conan default profile
        if: matrix.os == 'windows-latest'
-       run: conan profile new default --detect
+       run: conan profile detect --force
 
-     - uses: actions/cache@v3
+     - uses: actions/cache@v4
        if: matrix.os == 'windows-latest'
        with:
          path: ~/.conan
-         key: ${{ runner.os }}-conan-Release
+         key: ${{ runner.os }}-conan2-Release
 
 
      - name: Create Build Environment
@@ -82,17 +82,19 @@ jobs:
            echo  cmake .. $CONFIG_MAC -DBUILD_EXAMPLES=false -DBUILD_TESTING=false  -G Ninja
            cmake .. $CONFIG_MAC -DBUILD_EXAMPLES=false -DBUILD_TESTING=false  -G Ninja
            ninja
+           
      - name: DGtalBuild (windows)
        if: matrix.os == 'windows-latest'
        shell: bash
        working-directory: ${{runner.workspace}}/build
        run: |
+           conan install $GITHUB_WORKSPACE --build=missing
            git clone --depth 1 https://github.com/DGtal-team/DGtal.git
            cd DGtal
            mkdir buildDGtal
            cd buildDGtal
-           echo  cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DBUILD_EXAMPLES=false -DBUILD_TESTING=false 
-           cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DBUILD_EXAMPLES=false -DBUILD_TESTING=false  
+           echo  cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake"  -DBUILD_EXAMPLES=false -DBUILD_TESTING=false 
+           cmake .. -DCMAKE_BUILD_TYPE=$BUILD_TYPE $CONFIG_WINDOWS -DCMAKE_TOOLCHAIN_FILE="conan_toolchain.cmake" -DBUILD_EXAMPLES=false -DBUILD_TESTING=false  
            cmake --build . --config Release --parallel 3
 
      - name: Configure CMake (linux)
@@ -110,7 +112,9 @@ jobs:
        if: matrix.os == 'windows-latest'
        shell: bash
        working-directory: "${{runner.workspace}}/build"
-       run: cmake $GITHUB_WORKSPACE -DCMAKE_MODULE_PATH="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal" -DDGtal_DIR="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal"  -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DDGTAL_RANDOMIZED_TESTING_WHITELIST="${{ steps.whitelist.outputs.WHITELIST }}"
+       run: |
+           conan install $GITHUB_WORKSPACE --build=missing
+           cmake $GITHUB_WORKSPACE -DCMAKE_MODULE_PATH="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal" -DDGtal_DIR="D:/a/DGtalTools-contrib/build/DGtal/buildDGtal"  -DCMAKE_BUILD_TYPE=$BUILD_TYPE -DDGTAL_RANDOMIZED_TESTING_WHITELIST="${{ steps.whitelist.outputs.WHITELIST }}"
 
      - name: Build
        working-directory: ${{runner.workspace}}/build

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,8 +1,8 @@
 # DGtalTools-contrib  1.5 (beta)
 
 - *global*
-  - Continuous integration fix on update on conan version following DGtal.
-   (Bertrand Kerautret [#90](https://github.com/DGtal-team/DGtalTools-contrib/pull/90))
+  - Continuous integration fix using new version on conan following DGtal changes.
+    (Bertrand Kerautret [#90](https://github.com/DGtal-team/DGtalTools-contrib/pull/90))
 
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,8 @@
 # DGtalTools-contrib  1.5 (beta)
 
+- *global*
+  - Continuous integration fix on update on conan version following DGtal.
+   (Bertrand Kerautret [#90](https://github.com/DGtal-team/DGtalTools-contrib/pull/90))
 
 
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,0 +1,14 @@
+[requires]
+fmt/9.1.0
+zlib/1.2.13
+boost/1.81.0
+gmp/6.3.0
+fftw/3.3.9
+
+[generators]
+CMakeDeps
+CMakeToolchain
+
+[options] 
+boost*:header_only=True
+gmp*:enable_cxx=True


### PR DESCRIPTION
# PR Description
Continuous integration fix using new version on conan following DGtal changes.

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
