### PR TITLE
change default main instead master

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -7,8 +7,8 @@
 # Checklist
 
 - [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
-- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
-- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
+- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/main/CONTRIBUTING.md)
+- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/main/ChangeLog.md) added.
 - [ ] Update the readme with potentially a screenshot of the tools if it applies. 
 - [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
 - [ ] All continuous integration tests pass (Github Actions & appveyor).

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,9 +2,9 @@ name: CI (linux/macOS)
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,7 +84,7 @@ include_directories( "${PROJECT_SOURCE_DIR}/ext/" )
 # -----------------------------------------------------------------------------
 # SET(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake")
 SET(DGtalToolsContrib_VERSION_MAJOR 2)
-SET(DGtalToolsContrib_VERSION_MINOR 0)
+SET(DGtalToolsContrib_VERSION_MINOR 2)
 #SET(DGtalToolsContrib_VERSION_PATCH beta)
 SET(DGTALTOOLSContrib_VERSION "${DGtalToolsContrib_VERSION_MAJOR}.${DGtalToolsContrib_VERSION_MINOR}.${DGtalToolsContrib_VERSION_PATCH}")
 SET(PROJECT_VERSION "${DGtalToolsContrib_VERSION_MAJOR}.${DGtalToolsContrib_VERSION_MINOR}.${DGtalToolsContrib_VERSION_PATCH}")

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,11 @@
+# DGtalTools-contrib 2.2 (beta)
+
+- *global*
+  - Default branch set to main instead old master.
+   (Bertrand Kerautret [498](https://github.com/DGtal-team/DGtalTools/pull/98)) 
+
+
+
 
 # DGtalTools-contrib 2.1
 - *build* 

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ This section, can contain all tools related to visualisation:
 <table>
 <tr>
   <td align="center"><img width="95%" src="https://cloud.githubusercontent.com/assets/772865/12538777/cd8c2d28-c2e2-11e5-93ab-cb4a6cfadc8e.png"></td>
-  <td align="center" ><img width="95%" src="https://raw.githubusercontent.com/DGtal-team/DGtalTools-contrib/refs/heads/master/doc/images/previewGraphViewer.png"></td>
+  <td align="center" ><img width="95%" src="https://raw.githubusercontent.com/DGtal-team/DGtalTools-contrib/refs/heads/main/doc/images/previewGraphViewer.png"></td>
 </tr> 
  <tr>
  <td align="center">displayTgtCoverAlphaTS</td>


### PR DESCRIPTION
# PR Description
 Default branch set to main instead old master.

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
