### PR TITLE
new tool: meshFaceOrderColor

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,7 +4,10 @@
   - polyscope version to fix CI. 
     (Bertrand Kerautret [#97](https://github.com/DGtal-team/DGtalTools-contrib/pull/97))
 
-
+- *Geometry3d*
+  - meshFaceOrderColor: new tool to color a mesh based on face order and optionally sorts the faces lexicographically.
+    (Bertrand Kerautret [#98](https://github.com/DGtal-team/DGtalTools-contrib/pull/98))
+    
 # DGtalTools-contrib 2.0
 
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -6,7 +6,7 @@
 
 - *Geometry3d*
   - meshFaceOrderColor: new tool to color a mesh based on face order and optionally sorts the faces lexicographically.
-    (Bertrand Kerautret [#98](https://github.com/DGtal-team/DGtalTools-contrib/pull/98))
+    (Bertrand Kerautret [#99](https://github.com/DGtal-team/DGtalTools-contrib/pull/99))
     
 # DGtalTools-contrib 2.0
 

--- a/geometry3d/CMakeLists.txt
+++ b/geometry3d/CMakeLists.txt
@@ -10,6 +10,7 @@ SET(DGTAL_TOOLS_DEVEL_SRC
     volFillCCSize
     vol2meshAndNormals
     meshAxisCutter
+    meshFaceOrderColor
     graph2vol
     trunkMeshTransform
     splitMeshFromCol

--- a/geometry3d/meshFaceOrderColor.cpp
+++ b/geometry3d/meshFaceOrderColor.cpp
@@ -1,0 +1,169 @@
+/**
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU Lesser General Public License as
+ *  published by the Free Software Foundation, either version 3 of the
+ *  License, or  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ **/
+
+/**
+ * @file
+ * @ingroup geometry3d
+ * @author Bertrand Kerautret (\c bertrand.kerautret@univ-lyon2.fr )
+ * 
+ *
+ * @date 2026/04/04
+ *
+ * Source file of the tool meshFaceOrderColor
+ *
+ * This file is part of the DGtal library/DGtalTools-contrib Project.
+ */
+
+///////////////////////////////////////////////////////////////////////////////
+#include "DGtal/base/Common.h"
+#include "DGtal/helpers/StdDefs.h"
+#include <DGtal/shapes/Mesh.h>
+#include "DGtal/io/readers/MeshReader.h"
+#include "DGtal/io/writers/MeshWriter.h"
+#include "DGtal/io/colormaps/HueShadeColorMap.h"
+#include "CLI11.hpp"
+#include <vector>
+#include <algorithm>
+#include <map>
+
+
+///////////////////////////////////////////////////////////////////////////////
+using namespace std;
+using namespace DGtal;
+///////////////////////////////////////////////////////////////////////////////
+
+
+/**
+ @page meshOrderColor meshOrderColor
+ 
+ @brief  Description of the tool...
+
+ @b Usage:   meshOrderColor [input]
+
+ @b Allowed @b options @b are :
+ 
+ @code
+  -h [ --help ]           display this message
+  -i [ --input ] arg      an input file...
+  -p [ --parameter] arg   a double parameter...
+ @endcode
+
+ @b Example:
+
+ @code
+     meshOrderColor -i  $DGtal/examples/samples/....
+ @endcode
+
+ @image html resmeshOrderColor.png "Example of result. "
+
+ @see
+ @ref meshOrderColor.cpp
+
+ */
+
+
+typedef DGtal::Mesh<DGtal::Z3i::RealPoint> Mesh3D;
+typedef DGtal::Z3i::RealPoint Point;
+
+/**
+ * Sort mesh faces from barycenter
+ */
+Mesh3D sortFaces(const Mesh3D& inputMesh) {
+    Mesh3D resMesh;
+
+    const size_t nbV = inputMesh.nbVertex();
+    const size_t nbF = inputMesh.nbFaces();
+    for (size_t i = 0; i < nbV; ++i) {
+        resMesh.addVertex(inputMesh.getVertex(i));
+    }
+    // precompute barycenter
+    std::vector<Point> barycenters(nbF);
+    for (size_t i = 0; i < nbF; ++i) {
+        barycenters[i] = inputMesh.getFaceBarycenter(i);
+    }
+
+    std::vector<size_t> faceIds(nbF);
+    std::iota(faceIds.begin(), faceIds.end(), 0);
+    // ----------- 4. Tri par barycentre -----------
+    std::sort(faceIds.begin(), faceIds.end(),
+        [&](size_t a, size_t b) {
+            const auto& ca = barycenters[a];
+            const auto& cb = barycenters[b];
+            if (ca[0] != cb[0]) return ca[0] < cb[0];
+            if (ca[1] != cb[1]) return ca[1] < cb[1];
+            else return ca[2] < cb[2];
+        });
+    //add ordered faces to result
+    for (auto fid : faceIds) {
+        auto face = inputMesh.getFace(fid);
+        resMesh.addFace(face);
+    }
+    return resMesh;
+}
+
+int main( int argc, char** argv )
+{
+    bool sortLexico {false};
+    double parameter {1.0};
+    std::string inputFileName;
+    std::string outputFileName;
+    std::stringstream usage;
+
+    usage << "Usage: " << argv[0] << " [input]\n"
+    << "Typical use example:\n \t meshOrderColor -i ... \n";
+    // parse command line using CLI-------------------------------------------------------
+    CLI::App app;
+    app.description("Colors a mesh based on face order and optionally sorts the faces lexicographically." + usage.str() );
+    app.add_option("--input,-i,1", inputFileName, "Input mesh")->required()->check(CLI::ExistingFile);
+    app.add_option("--output,-o,2", outputFileName, "Output mesh")->required();
+    app.add_option("--sort-lexicographic,-s", sortLexico, "sorts the faces lexicographically.");
+    
+    app.get_formatter()->column_width(40);
+    CLI11_PARSE(app, argc, argv);
+    // END parse command line using CLI ----------------------------------------------
+    
+    
+    // Some nice processing  --------------------------------------------------
+    typedef DGtal::Mesh<DGtal::Z3i::RealPoint> Mesh3D;
+    Mesh3D inputMesh;
+    Mesh3D outputMesh;
+    
+    trace.info() << "Starting " << argv[0]  << "with input: " <<  inputFileName
+    << " and output :" << outputFileName
+    << " param: " << parameter <<std::endl;
+    trace.info() << "Reading the input mesh...";
+    inputMesh << inputFileName;
+    trace.info() << "[done]"<< endl;
+    trace.info() << "Sorting faces...";
+    if (sortLexico)
+    {
+        inputMesh = sortFaces(inputMesh);
+    }
+    trace.info() << "[done]"<< endl;
+    outputMesh = inputMesh;
+    HueShadeColorMap<unsigned long> hueMap(0, inputMesh.nbFaces());
+    for (unsigned long i=0; i < inputMesh.nbFaces(); i++){
+        outputMesh.setFaceColor(i, hueMap(i));
+    }
+    
+    trace.info() << "Writing the output mesh...";
+    outputMesh >> outputFileName;
+    trace.info() << "[done]"<< endl;
+    
+    return 0;
+}
+
+

--- a/geometry3d/meshFaceOrderColor.cpp
+++ b/geometry3d/meshFaceOrderColor.cpp
@@ -47,27 +47,41 @@ using namespace DGtal;
 
 
 /**
- @page meshOrderColor meshOrderColor
+ @page meshFaceOrderColor meshFaceOrderColor
  
- @brief  Description of the tool...
+ @brief  Colors a mesh based on face order and optionally sorts the faces
+ lexicographically.Usage: ./geometry3d/meshFaceOrderColor [input]
+ Typical use example:
+ meshFaceOrderColor $DGtal/examples/samples/bunnyhead.obj resColor.obj -s
 
  @b Usage:   meshOrderColor [input]
 
- @b Allowed @b options @b are :
- 
+ ./geometry3d/meshFaceOrderColor [OPTIONS] 1 2
+
  @code
-  -h [ --help ]           display this message
-  -i [ --input ] arg      an input file...
-  -p [ --parameter] arg   a double parameter...
+
+ POSITIONALS:
+   1 TEXT:FILE REQUIRED                  Input mesh
+   2 TEXT REQUIRED                       Output mesh
+
+ @b Allowed @b options @b are :
+
+ OPTIONS:
+   -h,        --help                     Print this help message and exit
+   -i,        --input TEXT:FILE REQUIRED Input mesh
+   -o,        --output TEXT REQUIRED     Output mesh
+   -s,        --sort-lexicographic       sorts the faces lexicographically.
+
+ 
+
  @endcode
 
  @b Example:
 
  @code
-     meshOrderColor -i  $DGtal/examples/samples/....
- @endcode
+       meshFaceOrderColor $DGtal/examples/samples/bunnyhead.obj resColor.obj -s
 
- @image html resmeshOrderColor.png "Example of result. "
+ @endcode
 
  @see
  @ref meshOrderColor.cpp
@@ -123,13 +137,13 @@ int main( int argc, char** argv )
     std::stringstream usage;
 
     usage << "Usage: " << argv[0] << " [input]\n"
-    << "Typical use example:\n \t meshOrderColor -i ... \n";
+    << "Typical use example:\n \t  meshFaceOrderColor $DGtal/examples/samples/bunnyhead.obj resColor.obj -s\n";
     // parse command line using CLI-------------------------------------------------------
     CLI::App app;
     app.description("Colors a mesh based on face order and optionally sorts the faces lexicographically." + usage.str() );
     app.add_option("--input,-i,1", inputFileName, "Input mesh")->required()->check(CLI::ExistingFile);
     app.add_option("--output,-o,2", outputFileName, "Output mesh")->required();
-    app.add_option("--sort-lexicographic,-s", sortLexico, "sorts the faces lexicographically.");
+    app.add_flag("--sort-lexicographic,-s", sortLexico, "sorts the faces lexicographically.");
     
     app.get_formatter()->column_width(40);
     CLI11_PARSE(app, argc, argv);


### PR DESCRIPTION
# PR Description
meshFaceOrderColor: new tool to color a mesh based on face order and optionally sorts the faces lexicographically.

# Checklist

- [ ] Doxygen documentation of the code completed (classes, methods, types, members...)
- [ ] Check if it follows the tools structure described in [CONTRIBUTING.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/CONTRIBUTING.md)
- [ ] New entry in the [ChangeLog.md](https://github.com/DGtal-team/DGtalTools-contrib/blob/master/ChangeLog.md) added.
- [ ] Update the readme with potentially a screenshot of the tools if it applies. 
- [ ] No warning raised in Debug ```cmake``` mode (otherwise, Travis C.I. will fail).
- [ ] All continuous integration tests pass (Github Actions & appveyor).
